### PR TITLE
bulk-chan

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ interval or threshold, you can specify these as options)
 (let [{:keys [input-ch output-ch]} (bulk-chan client {:flush-threshold 100
                                                       :flush-interval 5000
                                                       :max-concurrent-requests 3})]
+  ;; happily takes a sequence of actions or single fragments
   (async/put! input-ch [{:delete {:_index "foo" :_id "1234"}} {:_index :bar} {:create {...}}])
   (async/put! input-ch {"delete" {"_index" "website" "_type" "blog" "_id" "123"}}))
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ And it is quite fast already: See ["Benchmarking REST client and transport clien
       (when-let [page (async/<! ch)]
         (do-something-with-page page)
         (recur)))))
+
+
+;; "faux streaming" of _bulk requests (flushes bulk request after
+interval or threshold, you can specify these as options)
+
+(let [{:keys [input-ch output-ch]} (bulk-chan client {:flush-threshold 100
+                                                      :flush-interval 5000
+                                                      :max-concurrent-requests 3})]
+  (async/put! input-ch [{:delete {:_index "foo" :_id "1234"}} {:_index :bar} {:create {...}}])
+  (async/put! input-ch {"delete" {"_index" "website" "_type" "blog" "_id" "123"}}))
+
+;; setup an response consumer (we just want to make sure we don't clog this channel)
+(future (loop [] (async/<!! (:output-ch c))))
+
 ```
 
 ## Installation

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.qbits/spandex "0.1.10"
+(defproject cc.qbits/spandex "0.2.0"
   :description "Clojure Wrapper of the new/official ElasticSearch REST client"
   :url "https://github.com/mpenet/spandex"
   :license {:name "Eclipse Public License"

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -320,21 +320,23 @@
 
 (def bulk-chan
   "Bulk-chan takes a client, a partial request/option map, returns a
-  map of :input :output. :input is a channel that will accept bulk
-  fragments to be sent (either single or collection). It will
-  wait (:delay request-map) or (:max-items request-map) and then
-  trigger an async request with the bulk payload accumulated.
+  map of :input-ch :output-ch. :input-ch is a channel that will accept
+  bulk fragments to be sent (either single or collection). It will
+  wait (:flush-interval request-map) or (:flush-threshold request-map)
+  and then trigger an async request with the bulk payload accumulated.
   Parallelism of the async requests is controlable
-  via (:request-queue-size request-map). If number of triggered
+  via (:max-concurrent-requests request-map). If number of triggered
   requests exceed the capacity of the job buffer puts in input-ch will
   block (if done with put! you can check the return value before
   overflowing the put! pending queue). Jobs results returned from the
   processing are a pair of job and responses map, or exception.  The
   output-ch will allow you to inspect [job responses] the server
   returned and handle potential errors/failures accordingly (retrying
-  etc). If you close! the :input it will close the underlying
+  etc). If you close! the :input-ch it will close the underlying
   resources and exit cleanly (comsumming all jobs that remain in
-  queues)"
+  queues). By default requests are run against _bulk, but the option
+  map is passed as is to request-chan, you can overwrite options here
+  and provide your own url, headers and so on."
   (letfn [(par-run! [in-ch out-ch f n]
             (dotimes [_ n]
               (async/go

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -242,7 +242,8 @@
   returns a `core.async/promise-chan` that will have the result (or
   error) delivered upon reception"
   [^RestClient client options]
-  (let [ch (:chan options (async/promise-chan))]
+  (let [ch (or (:chan options)
+               (async/promise-chan))]
     (try
       (request-async client
                      (assoc options

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -303,23 +303,21 @@
         (async/close! ch)))
     ch))
 
-(defn bulk->body
-  "Utility function to create _bulk bodies. It takes a sequence of clj
-  maps representing _bulk document fragments and returns a newline
-  delimited string of JSON fragments"
-  [fragments]
+(defn chunks->body
+  "Utility function to create _bulk/_msearch bodies. It takes a
+  sequence of clj fragments and returns a newline delimited string of
+  JSON fragments"
+  [chunks]
   (let [sb (StringBuilder.)]
     (run! #(do (.append sb (json/generate-string %))
-               (.append sb"\n"))
-          fragments)
+               (.append sb "\n"))
+          chunks)
     (-> sb .toString Raw.)))
 
 ;; (def x (client ["http://localhost:9200"]))
 ;; (def s (sniffer x))
 ;; (request x {:url "entries/entry/_search" :method :get :body {}} )
 ;; (async/<!! (request-ch x {:url "/entries/entry" :method :post :body {:foo "bar"}} ))
-
-
 
 (def bulk-chan
   "Bulk-chan takes a client, a partial request/option map, returns a

--- a/test/qbits/spandex/test/core_test.clj
+++ b/test/qbits/spandex/test/core_test.clj
@@ -34,10 +34,10 @@
   (is (= (u/url []) ""))
   (is (= (u/url nil) "")))
 
-(deftest test-bulk
-  (is (= (:value (s/bulk->body [{:foo "bar"} {"bar" {:baz 1}}]))
+(deftest test-chunks
+  (is (= (:value (s/chunks->body [{:foo "bar"} {"bar" {:baz 1}}]))
          "{\"foo\":\"bar\"}\n{\"bar\":{\"baz\":1}}\n"))
-  (is (= (:value (s/bulk->body [])) "")))
+  (is (= (:value (s/chunks->body [])) "")))
 
 (deftest test-sync-query
   (is (->> (s/request client


### PR DESCRIPTION
The idea is to enable bulk operations via a core async channel and have throttling built in. Throttling would be either by max number of chunks to be sent or timeout ("send bulk request if payload has at least X chunks or if 1min passed since last bulk request") . The internals should take advantage of the fact that the underlying java client allows us to do this stuff asynchronously, but we must still allow the user to control parallelism, flow and handle back-pressure. We must also allow the user to plug reporting/retries of bulk operations.

This is just a draft, the implementation is open to discussion/changes.
The docstring should be quite self-explanatory. 

One caveat currently is that if the jvm crashes you can lose pending jobs. In theory it's possible for the end user to plug a durable store based solution to handle restarts by inspecting :input :ouput chans (only purging job from hard storage if it passed the output chan), but this might (or not) be something we could implement. 

