### PR TITLE
Fix NPE in json-entity?

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -183,7 +183,7 @@
       .getContentType
       .getValue
       (str/index-of "application/json")
-      (> -1)))
+      some?))
 
 (defn ^:no-doc response-status
   [^org.elasticsearch.client.Response response]


### PR DESCRIPTION
`str/index-of` will return `nil` when the needle is not found.
This in turn results in an NPE for the `(> -1)` comparison.