### PR TITLE
Feature/better ex handling

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -242,7 +242,7 @@
           (throw x)
           x)))))
 
-(def default-async-exception-handler
+(def async-default-exception-handler
   "Default async ex handler, values just pass through"
   (reify ExceptionHandler
     (handle-exception [this ex] ex)))


### PR DESCRIPTION
I might just throw away the default-* impls and have just 2 impl. of handlers with a default decoder that does `identity` instead. Still unsure. But that covers all the possible ways one might want to deal with exceptions (unchanged, with/without ex-info, throwing or not etc etc). 

I ll let it rest and see how I feel about it monday.  