### PR TITLE
Change auth key from :user to :username to match documentation.

### DIFF
--- a/src/clj/qbits/spandex/client_options.clj
+++ b/src/clj/qbits/spandex/client_options.clj
@@ -120,12 +120,12 @@
     (not cookie-management?) (.disableCookieManagement)))
 
 (defmethod set-http-client-option! :basic-auth
-  [_ ^HttpAsyncClientBuilder builder {:keys [user password]}]
+  [_ ^HttpAsyncClientBuilder builder {:keys [username password]}]
   (-> builder
       (.setDefaultCredentialsProvider
        (doto (BasicCredentialsProvider.)
          (.setCredentials AuthScope/ANY
-                          (UsernamePasswordCredentials. user
+                          (UsernamePasswordCredentials. username
                                                         password))))))
 
 ;; top level options

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -46,11 +46,11 @@
 (s/def ::http-client-options/auth-caching? boolean?)
 (s/def ::http-client-options/cookie-management? boolean?)
 (s/def ::http-client-options/basic-auth
-  (s/keys :req-un [::basic-auth/user
+  (s/keys :req-un [::basic-auth/username
                    ::basic-auth/password]))
 (s/def ::http-client-options/ssl-context #(instance? SSLContext %))
 (s/def ::http-client-options/proxy any?)
-(s/def ::basic-auth/user string?)
+(s/def ::basic-auth/username string?)
 (s/def ::basic-auth/password string?)
 
 (alias 'request-options (create-ns 'qbits.spandex.spec.client-options.request))


### PR DESCRIPTION
> `:basic-auth` (map of `:username` `:password`)

Perhaps, I should make the change in the other direction? Changing the documentation wouldn't break existing usage.

Closes #11.