### PR TITLE
Pass scroll parameters in a compatible way

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -354,8 +354,8 @@
           (loop []
             (let [response (async/<! (request-chan client
                                                    {:url "/_search/scroll"
-                                                    :body {:scroll ttl
-                                                           :scroll_id scroll-id}}))]
+                                                    :query-string {:scroll ttl}
+                                                    :body (Raw. scroll-id)}))]
               (cond
                 ;; it's an error and we must exit the consuming process
                 (or (instance? Throwable response)


### PR DESCRIPTION
Elasticsearch >= 2.0 changed the way pages are retrieved using scroll, instead of just passing the scroll-id as body, it takes a JSON object. This unfortunately fails when using older versions.

Thus it is also possible to continue passing the scroll-id as body and passing the scrolling TTL as query parameter, which should allow both newer and older versions of Elasticsearch to use the same request.

Fixes #12.