### PR TITLE
Add leading slash to the _bulk url

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -435,7 +435,7 @@
                 :or {flush-interval 5000
                      flush-threshold 300
                      max-concurrent-requests 3}}]
-       (let [request-map (merge {:url "_bulk"
+       (let [request-map (merge {:url "/_bulk"
                                  :method :put
                                  :headers {"content-type" "text/plain"}}
                                 request-map)


### PR DESCRIPTION
Having a forward slash is consistent with e.g. `scroll-chan` and `utils/url`, and sometimes saves from serious troubles.

I was setting up my application in AWS environment with [Amazon ElasticSearch Service](https://aws.amazon.com/elasticsearch-service/).

Everything was fine, except that `bulk-chan` didn't work. When I would try to execute the code like:

```clojure
;; localhost:9200 is a ssh tunnel, that directs me to Amazon'ss ES cluster
;; through a gateway machine.
(let [es (qbits.spandex/client {:hosts ["http://localhost:9200"]})
      {:keys [input-ch output-ch]} (qbits.spandex/bulk-chan es)
      ops [{:index {:_index :test
                    :_type  :test
                    :_id    1}}
           {}]]
  (clojure.core.async/put! input-ch ops)
  (clojure.core.async/go-loop []
    (clojure.pprint/pprint (clojure.core.async/<!! output-ch)))
  (clojure.core.async/close! input-ch))
```

I would get 400 BAD_REQUEST with no body:

```clojure
[{:type clojure.lang.ExceptionInfo
  :message "Response Exception"
  :data #qbits.spandex.Response{:body "", :status 400, :headers {"Content-Length" "0", "Connection" "Close"}, :hosts #object[org.apache.http.HttpHost 0x602a2cdc "http://localhost:9200"], :type :qbits.spandex/response-exception}}]
```

Capturing the requests with `ngrep` gave me the following

```
T *.*.*.*:**** -> *.*.*.*:**** [AP]
  PUT _bulk HTTP/1.1..content-type: text/plain..Content-Length: 54..Host: localhost:9200..Connection: Keep-Alive..User-Agent: Apache-HttpAsyncClient/4.1.2 (Java/1.8.0_74)....{"index":{"_index":"test","_type":"test","_id":1}}.{}.

T *.*.*.*:**** -> *.*.*.*:**** [AP]
  HTTP/1.1 400 BAD_REQUEST..Content-Length: 0..Connection: Close....
```

The same code would work just fine with a self-hosted ES.
After long time of eyegazing and trying many different things, I realized that the problem is due to missing leading slash, which causes some pedantic AWS's proxy to reject the requests.

Adding the slash fixed the problem:

```
T *.*.*.*:**** -> *.*.*.*:**** [AP]
  PUT /_bulk HTTP/1.1..content-type: text/plain..Content-Length: 54..Host: localhost:9200..Connection: Keep-Alive..User-Agent: Apache-HttpAsyncClient/4.1.2 (Java/1.8.0_74)....{"index":{"_index":"test","_type":"test","_id":1}}.{}.

T *.*.*.*:**** -> *.*.*.*:**** [AP]
  HTTP/1.1 200 OK..Access-Control-Allow-Origin: *..Content-Type: application/json; charset=UTF-8..Content-Length: 198..Connection: keep-alive....{"took":9,"errors":false,"items":[{"index":{"_index":"test","_type":"test","_id":"1","_version":10,"result":"updated","_shards":{"total":2,"successful":2,"failed":0},"created":false,"status":200}}]}
```