### PR TITLE
Upgrade dependencies (ES client, ring-codec & lein plugins)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def es-client-version "6.2.2")
+(def es-client-version "6.3.1")
 (defproject cc.qbits/spandex "0.6.3"
   :description "Clojure Wrapper of the new/official ElasticSearch REST client"
   :url "https://github.com/mpenet/spandex"
@@ -6,12 +6,15 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.474"]
-                 [org.elasticsearch.client/elasticsearch-rest-client ~es-client-version]
+                 [org.elasticsearch.client/elasticsearch-rest-client ~es-client-version
+                  ; more recent through ring/ring-codec
+                  :exclusions [commons-codec]]
                  [org.elasticsearch.client/elasticsearch-rest-client-sniffer ~es-client-version
-                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                   :exclusions [com.fasterxml.jackson.core/jackson-core
+                                commons-codec]]
                  [cc.qbits/commons "0.5.1"]
                  [cheshire "5.8.0"]
-                 [ring/ring-codec "1.1.0"]]
+                 [ring/ring-codec "1.1.1"]]
   :source-paths ["src/clj"]
   :global-vars {*warn-on-reflection* true}
   :codox {:source-uri "https://github.com/mpenet/spandex/blob/master/{filepath}#L{line}"
@@ -20,6 +23,6 @@
           :doc-files ["docs/quickstart.md"]
           :source-paths ["src/clj"]}
   :pedantic? :warn
-  :profiles {:dev {:plugins [[lein-cljfmt "0.5.6"
+  :profiles {:dev {:plugins [[lein-cljfmt "0.6.0"
                               :exclusions [org.clojure/clojurescript]]
-                             [codox "0.10.3"]]}})
+                             [codox "0.10.4"]]}})


### PR DESCRIPTION
Upgrade the following dependencies:
- ES client 6.2.2 => 6.3.1
- ring-codec 1.1.0 => 1.1.1
- lein-cljfmt 0.5.6 => 0.6.0
- codox 0.10.3 => 0.10.4