### PR TITLE
Remove the :decompression? client parameter (fixes #35)

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -57,7 +57,6 @@
       *  `:connect-timeout`
       *  `:connection-request-timeout`
       *  `:content-compression?`
-      *  `:decompression?`
       *  `:expect-continue?`
       *  `:local-address`
       *  `:max-redirects`

--- a/src/clj/qbits/spandex/client_options.clj
+++ b/src/clj/qbits/spandex/client_options.clj
@@ -49,10 +49,6 @@
   [_ ^RequestConfig$Builder builder cookie-spec]
   (.setCookieSpec builder cookie-spec))
 
-(defmethod set-request-option! :decompression?
-  [_ ^RequestConfig$Builder builder decompression?]
-  (.setDecompressionEnabled builder (boolean decompression?)))
-
 (defmethod set-request-option! :expect-continue?
   [_ ^RequestConfig$Builder builder expect-continue?]
   (.setExpectContinueEnabled builder (boolean expect-continue?)))

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -62,7 +62,6 @@
                    ::request-options/connect-request-timeout
                    ::request-options/content-compression?
                    ::request-options/cookie-spec
-                   ::request-options/decompression?
                    ::request-options/expect-continue?
                    ::request-options/local-address
                    ::request-options/cookie-spec
@@ -75,7 +74,6 @@
 (s/def ::request-options/authentication? boolean?)
 (s/def ::request-options/circular-redirect-allowed? boolean?)
 (s/def ::request-options/content-compression? boolean?)
-(s/def ::request-options/decompression? boolean?)
 (s/def ::request-options/expect-continue? boolean?)
 (s/def ::request-options/redirect? boolean?)
 (s/def ::request-options/relative-redirects-allowed? boolean?)


### PR DESCRIPTION
As spotted by #35, .setDecompressionEnabled is deprecated: https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html#setDecompressionEnabled(boolean)