### PR TITLE
Fix scroll-id larger than 4K causing  `too_long_frame_exception`

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -377,9 +377,10 @@
           (loop [scroll-id scroll-id]
             (let [response
                   (async/<! (request-chan client
-                                          {:url "/_search/scroll"
-                                           :query-string {:scroll_id scroll-id
-                                                          :scroll ttl}}))]
+                                          {:method :post
+                                           :url "/_search/scroll"
+                                           :body {:scroll_id scroll-id
+                                                  :scroll ttl}}))]
               ;; it's an error and we must exit the consuming process
               (if (or (instance? Exception response)
                       (not= 200 (:status response)))


### PR DESCRIPTION
In Elasticsearch versions greater than 1.4, Its possible an attempt to scroll across multiple indexes will generate a scroll-id larger than 4k, causing scrolls using GET requests to fail with 

```#error {:cause Response Exception
 :data #qbits.spandex.Response{
     :body {
         :error {
             :root_cause [{
                 :type too_long_frame_exception, 
                 :reason An HTTP line is larger than 4096 bytes.
                }], 
             :type too_long_frame_exception, 
             :reason An HTTP line is larger than 4096 bytes.
         }, 
         :status 400
    }
 }
```

Ensuring the scroll request always use POST should support these scenarios.