### PR TITLE
Pass options to all scroll requests and clear scroll upon completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/.cpcache/
+/.lein-failures

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -393,6 +393,15 @@
                   (when (and (-> body :hits :hits seq)
                              (async/>! ch response))
                     (recur (:_scroll_id body))))))))
+
+        ;; When we're done with a scroll we tidy it up early.
+        ;; Otherwise we have to wait for the ttl to expire.
+        ;; Let's be nice to ES.
+        (async/<! (request-chan client
+                                {:method :delete
+                                 :url "/_search/scroll"
+                                 :body {:scroll_id scroll-id}}))
+
         (async/close! ch)))
     ch))
 

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -377,10 +377,11 @@
           (loop [scroll-id scroll-id]
             (let [response
                   (async/<! (request-chan client
-                                          {:method :post
-                                           :url "/_search/scroll"
-                                           :body {:scroll_id scroll-id
-                                                  :scroll ttl}}))]
+                                          (merge request-map
+                                                 {:method :post
+                                                  :url "/_search/scroll"
+                                                  :body {:scroll_id scroll-id
+                                                         :scroll ttl}})))]
               ;; it's an error and we must exit the consuming process
               (if (or (instance? Exception response)
                       (not= 200 (:status response)))

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -107,7 +107,7 @@
 
 (s/def ::request/url #(satisfies? qbits.spandex.url/URL %))
 (s/def ::request/scheme #{:http :https})
-(s/def ::request/method #{:get :post :put :head})
+(s/def ::request/method #{:get :post :put :head :delete})
 (s/def ::request/headers (s/map-of (s/or :kw keyword? :str string?)
                                    string?))
 (s/def ::request/query-string (s/map-of (s/or :kw keyword? :str string?)


### PR DESCRIPTION
We're using some tracing tools to trace our requests to our ES cluster, when we use `scroll-chan` those tracing headers are lost. They make it to the first request since the headers are passed through but they're not provided to all subsequent scroll requests.

I've changed `scroll-chan` to pass the `request-map` to each call to `/_search/scroll`. This will allow clients to provide their own headers etc.

I've also addressed #47 by clearing scrolls when we're done with them instead of leaving them for the TTL. This should reduce the load on some ES instances when making heavy use of scroll requests.

I also took the liberty to add some `.gitignore` lines, I hope that's okay!