### PR TITLE
Pass headers (etc) through to scroll DELETE

### DIFF
--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -398,9 +398,10 @@
         ;; Otherwise we have to wait for the ttl to expire.
         ;; Let's be nice to ES.
         (async/<! (request-chan client
-                                {:method :delete
-                                 :url "/_search/scroll"
-                                 :body {:scroll_id scroll-id}}))
+                                (merge request-map
+                                       {:method :delete
+                                        :url "/_search/scroll"
+                                        :body {:scroll_id scroll-id}})))
 
         (async/close! ch)))
     ch))


### PR DESCRIPTION
Co-authored-by: Sam Burrell <sam.burrell@signal-ai.com>

This is a small continuation on from #49, we noticed the deletes were happening correctly but they weren't being captured by our tracing. This change corrects that.