### PR TITLE
Bump dependencies & cljfmt all the code

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/core.async {:mvn/version "0.4.500"}
-  org.elasticsearch.client/elasticsearch-rest-client {:mvn/version "7.2.0"}
+  org.clojure/core.async {:mvn/version "0.6.532"}
+  org.elasticsearch.client/elasticsearch-rest-client {:mvn/version "7.5.0"}
   org.elasticsearch.client/elasticsearch-rest-client-sniffer
-  {:mvn/version "7.1.0"
+  {:mvn/version "7.5.0"
    :exclusions [com.fasterxml.jackson.core/jackson-core]}
   cc.qbits/commons {:mvn/version "0.5.2"}
-  cheshire {:mvn/version "5.8.1"}
-  ring/ring-codec {:mvn/version "1.1.1"}}
+  cheshire {:mvn/version "5.9.0"}
+  ring/ring-codec {:mvn/version "1.1.2"}}
 
  :paths ["src/clj"]
 
@@ -18,6 +18,6 @@
            :cljfmt {:extra-deps {com.jameslaverack/cljfmt-runner {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
                                                                   :sha "fc12c2724c44185cd1b221a79c8486c73846f14c"
                                                                   :exclusions [cljfmt]}
-                                 cljfmt {:mvn/version "0.6.1"}}
+                                 cljfmt {:mvn/version "0.6.4"}}
                     :main-opts ["-m" "cljfmt-runner.check"]}
            :cljfmt/fix {:main-opts ["-m" "cljfmt-runner.fix"]}}}

--- a/project.clj
+++ b/project.clj
@@ -1,20 +1,20 @@
-(def es-client-version "7.4.2")
+(def es-client-version "7.5.0")
 (defproject cc.qbits/spandex "0.7.4-SNAPSHOT"
   :description "Clojure Wrapper of the new/official ElasticSearch REST client"
   :url "https://github.com/mpenet/spandex"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.500"]
+                 [org.clojure/core.async "0.6.532"]
                  [org.elasticsearch.client/elasticsearch-rest-client ~es-client-version]
                  [org.elasticsearch.client/elasticsearch-rest-client-sniffer ~es-client-version
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [cc.qbits/commons "0.5.2"]
-                 [cheshire "5.8.1"]
-                 [ring/ring-codec "1.1.1"]]
+                 [cheshire "5.9.0"]
+                 [ring/ring-codec "1.1.2"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :source-paths ["src/clj"]
   :global-vars {*warn-on-reflection* true}
   :pedantic? :warn
-  :profiles {:dev {:plugins [[lein-cljfmt "0.6.1"
+  :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"
                               :exclusions [org.clojure/clojurescript]]]}})

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -485,8 +485,8 @@
                    #(request-chan client (build-map request-map %))
                    max-concurrent-requests)
          (async/go-loop
-             [payload []
-              timeout-ch (async/timeout flush-interval)]
+          [payload []
+           timeout-ch (async/timeout flush-interval)]
            (let [[chunk ch] (async/alts! [timeout-ch input-ch])]
              (cond
                (= timeout-ch ch)

--- a/src/clj/qbits/spandex/client_options.clj
+++ b/src/clj/qbits/spandex/client_options.clj
@@ -188,7 +188,7 @@
 (defn builder [{:as options
                 :keys [hosts]}]
   (let [b (RestClient/builder  ^"[Lorg.apache.http.HttpHost;"
-                              (into-array HttpHost
-                                          (map #(HttpHost/create %) hosts)))]
+           (into-array HttpHost
+                       (map #(HttpHost/create %) hosts)))]
     (set-options! b options)
     (.build b)))

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -2,7 +2,6 @@
   (:require
    [qbits.spandex]
    [clojure.spec.alpha :as s]
-   [clojure.core.async :as async]
    [qbits.spandex.url]
    [qbits.spandex.utils :as u])
   (:import

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -121,7 +121,7 @@
 (s/def ::request/exception-handler
   fn?
   ;; (s/fspec :args (s/cat :throwable #(instance? Throwable %)))
-)
+  )
 
 (alias 'response (create-ns 'qbits.spandex.spec.response))
 (s/def ::response (s/keys :req-un [::response/body


### PR DESCRIPTION
Bump the following dependencies:
- core.async 0.4.500 :arrow_right: 0.6.532
- elasticsearch client 7.2.0 :arrow_right: 7.5.0
- cheshire 5.8.1 :arrow_right: 5.9.0
- ring-codec 1.1.1 :arrow_right: 1.1.2
- cljfmt 0.6.1 :arrow_right: 0.6.4

Code is also re-indented & an unneeded require is removed :smiley: 