### PR TITLE
Implement Search After based on refactored scroll-chan

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [org.elasticsearch.client/elasticsearch-rest-client-sniffer ~es-client-version
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [cc.qbits/commons "0.5.2"]
-                 [cheshire "5.9.0"]
+                 [cheshire "5.10.0"]
                  [ring/ring-codec "1.1.2"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :source-paths ["src/clj"]

--- a/src/clj/qbits/spandex/utils.clj
+++ b/src/clj/qbits/spandex/utils.clj
@@ -11,8 +11,9 @@
 
   Will block on after the last element if the channel is not closed."
   [ch]
-  (when-let [v (async/<!! ch)]
-    (cons v (lazy-seq (chan->seq ch)))))
+  ; FIXME: if the lazy-seq isn't fully read, the underlying async is never closed!
+  (->> (repeatedly #(async/<!! ch))
+       (take-while some?)))
 
 (defn escape-query-string
   "Escape or remove special characters in query string coming from users.

--- a/test/qbits/spandex/test/core_test.clj
+++ b/test/qbits/spandex/test/core_test.clj
@@ -22,7 +22,7 @@
 
 (def doc {:some {:fancy "thing"}})
 (def doc-id (java.util.UUID/randomUUID))
-(def client (s/client))
+(def client (s/client {:hosts [server]}))
 (def sniffer (s/sniffer client))
 
 (defn wait! []


### PR DESCRIPTION
We noticed some performance issue because we're solely using ES scroll to retrieve pages of results of our queries for "real-time" requests, however it's [strongly discouraged in the doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html). Here we opt to implement [Search After](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-search-after.html) which is very close to scroll-chan, the difference is the necessity to have a proper ordering through :sort

Note that this PR refactored and simplified scroll-chan plus we fixed a possible bug: we always pick the last scroll, acquired from the last page, which wasn't the case before. As [described in the doc](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html), we should always use the lastest scroll.

Other note, We noticed that chan->seq doesn't properly close the chan when the seq isn't entirely consumed. We also simplified it using simple clojure functions. This issue was already here and no idea how to fix it yet :/ Any idea welcomed.