### PR TITLE
Add ssl-noop-no-hostname-verifier options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ Not to mention it supports some interesting features:
 (def s (s/sniffer c {... options ...}))
 ```
 
+#### Work with `https` via ssh tunneling
+
+First setup and make sure that you have appropriate access to the host via tunneling.
+
+e.g. Add/edit your `~/.ssh/config` to look something like
+
+```
+# Example of tunneling in ~/.ssh/config
+# .. more config
+Host my-aws-elasticsearch-host 
+  HostName 10.123.345.456
+  User ec2-user
+  IdentitiesOnly yes
+  IdentityFile ~/.ssh/my-aws-elasticsearch.pem
+  LocalForward 9200 vpc-my-aws-elasticsearch-host-lb43i.us-east-1.es.amazonaws.com:443
+  ServerAliveInterval 240
+# .. more config
+```
+
+You can then start ssh tunneling with 
+
+``` sh
+# see manpage of `ssh` for more details
+ssh -oStrictHostKeyChecking=no my-aws-elasticsearch-host -N 
+```
+
+Then you can create your client using the following `:http-client` options like
+
+```clojure
+;; if you are using tunnelling to host in AWS e.g.
+(def client (s/client {:hosts ["https://localhost:9200"]
+                       :http-client {:ssl-context (client/ssl-context-trust-all)
+                                     :ssl-noop-hostname-verifier? true}}))
+```
+
 #### Constructing URLs
 
 Most of spandex request functions take a request map as parameter. The

--- a/src/clj/qbits/spandex.clj
+++ b/src/clj/qbits/spandex.clj
@@ -71,6 +71,7 @@
       *  `:max-conn-total`
       *  `:proxy`
       *  `:ssl-context`
+      *  `:ssl-noop-hostname-verifier?`
       *  `:user-agent`
       *  `:auth-caching?`
       *  `:cookie-management?`

--- a/src/clj/qbits/spandex/client_options.clj
+++ b/src/clj/qbits/spandex/client_options.clj
@@ -17,6 +17,8 @@
    (org.apache.http.ssl
     SSLContextBuilder
     TrustStrategy)
+   (org.apache.http.conn.ssl
+    NoopHostnameVerifier)
    (org.elasticsearch.client
     RestClient
     RestClientBuilder
@@ -112,6 +114,12 @@
 (defmethod set-http-client-option! :ssl-context
   [_ ^HttpAsyncClientBuilder builder ssl-context]
   (.setSSLContext builder ssl-context))
+
+(defmethod set-http-client-option! :ssl-noop-hostname-verifier?
+  [_ ^HttpAsyncClientBuilder builder ssl-noop-hostname-verifier?]
+  (cond-> builder
+    ssl-noop-hostname-verifier?
+    (.setSSLHostnameVerifier NoopHostnameVerifier/INSTANCE)))
 
 (defmethod set-http-client-option! :user-agent
   [_ ^HttpAsyncClientBuilder builder user-agent]

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -37,6 +37,7 @@
                    ::http-client-options/max-conn-total
                    ::http-client-options/proxy
                    ::http-client-options/ssl-context
+                   ::http-client-options/ssl-noop-hostname-verifier?
                    ::http-client-options/user-agent
                    ::http-client-options/basic-auth
                    ::http-client-options/auth-caching?
@@ -50,6 +51,7 @@
   (s/keys :req-un [::basic-auth/user
                    ::basic-auth/password]))
 (s/def ::http-client-options/ssl-context #(instance? SSLContext %))
+(s/def ::http-client-options/ssl-noop-hostname-verifier? boolean?)
 (s/def ::http-client-options/proxy any?)
 (s/def ::basic-auth/user string?)
 (s/def ::basic-auth/password string?)


### PR DESCRIPTION
Hi @mpenet,

Thanks for a great library.

I had some issues when trying to connect to the tunnelling host of ES in AWS system.

This PR makes it possible to work with ES hosted in AWS via tunnelling.

Note this fix the issue with https://github.com/mpenet/spandex/issues/57

And prevent the following errors when trying to connect to ElasticSearch in AWS for me.

```
Caused by javax.net.ssl.SSLPeerUnverifiedException
   Host name 'localhost' does not match the certificate subject provided by the
   peer (CN=*.us-east-1.es.amazonaws.com)
```
I updated the example in the README to reflect the same.
Please let me know if you have any questions or if you need me to update anything.

Thanks
