### PR TITLE
Fix spec declarations, add return spec instrumentation, tidy up core_test.clj. test with Opensearch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [cc.qbits/commons "0.5.2"]
                  [cheshire "5.9.0"]
+                 [orchestra "2021.01.01-1"]
                  [ring/ring-codec "1.1.2"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :source-paths ["src/clj"]

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,11 @@
                   :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [cc.qbits/commons "0.5.2"]
                  [cheshire "5.9.0"]
-                 [orchestra "2021.01.01-1"]
                  [ring/ring-codec "1.1.2"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :source-paths ["src/clj"]
   :global-vars {*warn-on-reflection* true}
   :pedantic? :warn
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"
-                              :exclusions [org.clojure/clojurescript]]]}})
+                              :exclusions [org.clojure/clojurescript]]]}
+             :test {:dependencies [[orchestra "2021.01.01-1"]]}})

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -126,12 +126,13 @@
 (s/def ::response (s/keys :req-un [::response/body
                                    ::response/status
                                    ::response/headers
-                                   ::response/host]))
+                                   (or ::response/host ::response/hosts)]))
 
 (s/def ::response/headers (s/map-of string? string?))
 (s/def ::response/status pos-int?)
 (s/def ::response/body (s/nilable any?)) ;; edn/clj?
 (s/def ::response/host any?) ;; to be refine
+(s/def ::response/hosts any?) ;; to match 'hosts' field in Response record
 
 (s/def ::request-async
   (s/merge ::request
@@ -156,7 +157,7 @@
 
 (s/fdef qbits.spandex/chunks->body
   :args (s/cat :fragments (s/coll-of map?))
-  :ret string?)
+  :ret  #(instance? qbits.spandex.Raw %))
 
 (s/def ::ttl int?)
 (s/def ::ch int?)
@@ -188,5 +189,4 @@
 
 (s/fdef qbits.spandex.utils/chan->seq
   :args (s/cat :chan ::chan)
-  :ret (s/nilable (s/coll-of (s/or :response ::response
-                                   :exception #(instance? Exception %)))))
+  :ret (s/nilable (s/coll-of some?)))

--- a/test/qbits/spandex/test/core_test.clj
+++ b/test/qbits/spandex/test/core_test.clj
@@ -1,41 +1,73 @@
 (ns qbits.spandex.test.core-test
-  (:refer-clojure :exclude [type])
-  (:use clojure.test)
   (:require
    [clojure.core.async :as async]
+   [clojure.spec.alpha :as spec]
+   [clojure.test :refer :all]
+   [orchestra.spec.test :as spec.test]
    [qbits.spandex :as s]
    [qbits.spandex.url :as url]
    [qbits.spandex.utils :as utils])
   (:import (qbits.spandex Response)))
 
-(try
-  (require 'qbits.spandex.spec)
-  (require 'clojure.spec.test.alpha)
-  ((resolve 'clojure.spec.test.alpha/instrument))
-  (println "Instrumenting qbits.spandex with clojure.spec")
-  (catch Exception e
-    (.printStackTrace e)))
-
-(def server "http://127.0.0.1:9200")
 (def index (java.util.UUID/randomUUID))
-(def type (java.util.UUID/randomUUID))
-
 (def doc {:some {:fancy "thing"}})
 (def doc-id (java.util.UUID/randomUUID))
-(def client (s/client))
-(def sniffer (s/sniffer client))
 
-(defn wait! []
-  (Thread/sleep 3000))
 
+(def client 
+  "The traditional client configuration used with Elasticsearch 7.6 containers for testing."
+  (s/client))
+#_
+(def client 
+  "Opensearch client for typical Opensearch demo container. E.g. docker container
+  'opensearchproject/opensearch:latest'.  Recent testing used Opensearch 2.0.1"
+  (s/client {:hosts ["https://127.0.0.1:9200"]
+             :http-client {:ssl-context (qbits.spandex.client-options/ssl-context-trust-all)
+                           :basic-auth  {:user "admin" :password "admin"}}}))
+
+(def sniffer
+  "If a sniffer is created, asynchronous sniffer logic will query the Elastic/Open-search
+  service and try to determine what hosts can be used for requests.  It will fail verbosely
+  if you have not configured your docker setup to work with sniffers. This article _may_ help:
+  https://www.elastic.co/blog/elasticsearch-sniffing-best-practices-what-when-why-how
+
+  You may wish to comment out the sniffer definition if you haven't configured your docker
+  setup to work with it.  It may be broken for other reasons with Opensearch, Opensearch
+  sniffer testing has not yet been done successfully."
+  (s/sniffer client))
+
+(defn once-fixture [f]
+  (try 
+    (binding [spec/*fspec-iterations* 0]
+      (spec.test/instrument)
+      ;; Ensure we can do basic service access, otherwise all the tests will fail
+      ;; with tedious and unhelpful stack traces about connections being closed.
+      (s/request client {:url [:_cat :templates]})
+      ;; Note that F's exceptions will not reach this point, it's intercepted
+      ;; by the unit test machinery and reported as an uncaught exception
+      (f)
+      (spec.test/unstrument))
+    (catch Exception e
+      (binding [*out* *err*]
+        (println "Exception in :once fixture:" (.getMessage e))
+        (println "Opensearch / Elasticsearch service probably not reachable or requires credentials missing from the client."))
+      (.printStackTrace e))))
+
+(use-fixtures :once once-fixture)
 (use-fixtures
   :each
   (fn [t]
     (try
       (s/request client
                  {:method :delete
-                  :url [index type]})
-      (catch Exception _ nil))
+                  :url [index]})
+      (catch clojure.lang.ExceptionInfo ei
+        ;; Index not found is okay, anything else is not okay.
+        (when-not (= (-> ei ex-data :body :error :root_cause first :type)
+                     "index_not_found_exception")
+          (println "OOPS:" ei)))
+      (catch Exception e 
+        (println "OOPS:" e) nil))
     (t)))
 
 (deftest test-url
@@ -56,21 +88,21 @@
 
 (deftest test-sync-query
   (is (->> (s/request client
-                      {:url [index type doc-id]
+                      {:url [index :_doc doc-id]
                        :method :post
                        :body doc})
            :status
            (contains? #{200 201})))
 
   (is (-> (s/request client
-                     {:url [index type doc-id]
+                     {:url [index :_doc doc-id]
                       :method :get})
           :body
           :_source
           (= doc)))
 
   (is (-> (s/request client
-                     {:url [index type doc-id]
+                     {:url [index :_doc doc-id]
                       :method :get
                       :keywordize? false})
           :body
@@ -78,20 +110,24 @@
           (= (clojure.walk/stringify-keys doc)))))
 
 (deftest test-head-req
+  (s/request client
+             {:url [index :_doc doc-id]
+              :method :post
+              :body doc})
   (is (-> (s/request client
-                     {:url [index type doc-id]
+                     {:url [index :_doc doc-id]
                       :method :head})
           :body
           nil?)))
 
 (deftest test-async-sync-query
   (s/request client
-             {:url [index type doc-id]
+             {:url [index :_doc doc-id]
               :method :post
               :body doc})
   (let [p (promise)]
     (s/request-async client
-                     {:url [index type doc-id]
+                     {:url [index :_doc doc-id]
                       :method :get
                       :success (fn [response]
                                  (deliver p response))
@@ -99,14 +135,20 @@
                                (deliver p response))})
     (is (contains? #{200 201} (:status @p)))))
 
-(deftest test-scrolling-chan
+(defn post-99-docs-and-refresh! []
+  "Load 99 documents (one at a time, for no other reason than that's how it's been done) and
+  request a shard refresh so that all docs will be visible to subsequent tests."
   (dotimes [i 99]
     (s/request client
-               {:url [index type (str i)]
-                :method :post
-                :body doc}))
-  (wait!)
-  (let [ch (s/scroll-chan client {:url [index type :_search]})]
+                {:url [index :_doc (str i)]
+                 :method :post
+                 :body doc}))
+  (s/request client {:url [index :_refresh]
+                     :method :post}))
+
+(deftest test-scrolling-chan
+  (post-99-docs-and-refresh!)
+  (let [ch (s/scroll-chan client {:url [index :_search]})]
     (-> (async/go
           (loop [docs []]
             (if-let [docs' (-> (async/<! ch) :body :hits :hits seq)]
@@ -114,17 +156,12 @@
               docs)))
         async/<!!
         count
-        (= 100)
+        (= 99)
         is)))
 
 (deftest test-scrolling-chan-interupted
-  (dotimes [i 99]
-    (s/request client
-               {:url [index type (str i)]
-                :method :post
-                :body doc}))
-  (wait!)
-  (let [ch (s/scroll-chan client {:url [index type :_search]
+  (post-99-docs-and-refresh!)
+  (let [ch (s/scroll-chan client {:url [index :_search]
                                   :body {:size 1}})]
     (-> (async/go
           (loop [docs []


### PR DESCRIPTION
TL;DR: make spec declarations work with return-validating instrumentation support Opensearch in the core_test execution, fix test pre-existing test case bugs, and tidy up some of the setup logic in the test.

It probably should have been separate commits (one for specs, one for tests), sorry 'bout that.

1. Corrects some bugs in clojure specs for return values of some functions. This is necessary for organizations enabling return spec validation if they want to call spandex APIs from their own tests.  The alternative is to write instrumentation logic that avoids instrumenting the spandex namespaces.

2. Adds 'orchestra' to dependencies and enables its instrumentation so that clojure.spec return values are routinely checked in spandex unit tests. Note that clojure.test.spec.alpha's instrumentation does not check return values.

3. Cleans up the core_test.clj module to to perform some test setup in a fixture instead of in a top level form in the module at load/compile-time.

   I left the connection client initialization as a top level form for now in case it's useful for debugging client interactions in the REPL, though it isn't a particularly tidy thing to do.

4. Validates the core_test.clj module against an Opensearch container instead of Elasticsearch, in order ensure at least minimal Opensearch compatibility.

   Note that while Opensearch forked Elasticsearch at 7.10 or so, Opensearch contines on its own somewhat divergent path separate from Elasticsearch and it's hard to say what sorts of complications may preclude future use of Spandex with Opensearch.  That said, Opensearch 2.0.1 service works with Spandex as of January 1, 2023 (with the changes in this PR - AFAIK - sniffing not verified).

5. Change use of depreciated Elasticsearch APIs to use their replacements. Spandex is currently testing against containers running Elasticsearch 7.6, which happily takes syntax which has since been deprecated later in the 7.x branch sequence.

   Elasticsearch 7.15 deprecates POST syntax of `/index/type/doc-id` in favor of `/index/_doc/doc-id`.  For details see: https://www.elastic.co/guide/en/elasticsearch/reference/7.15/removal-of-types.html

   Similarly `/index/type/_search` is now `/index/_search` for scrolling tests.

   While deprecated constructs only generate warnings in later versions of Elasticsearch, it errors completely out in more recent versions of Opensearch.

6. Fixes broken core_test.clj test cases that couldn't possibly have run succesfully via `lein test`, AFAICT. The two broken tests are:

   `test-head-req` which is doing a HEAD on a document that doesn't exist, and getting a 404 when it doesn't seem to expect a 404.  I've changed the test to create a document before doing a HEAD on it.

   `test-scrolling-chan` was broken because it was posting 99 documents and then asserting that 100 documents were read. I've changed the assertion to be 99.

7. Replaced the `wait!` function that did a `Thread/sleep` with a `POST /index/_refresh` which is what I assume `wait!` was waiting for.  Thread/sleep is never a good synchronization mechanism.

I verified tests with Elasticsearch 7.6.1 and Opensearch 2.0.1 containers. Everything worked with 7.6.1, the version used in the github ci setup. Everything worked, with security warnings, with ES 7.17.8.

Sniffing (and only sniffing) fails with Opensearch 2.0.1.  Whether it's a problem with container host mapping setup or Opensearch specific issues I don't know.  I haven't attempted to fix this problem yet.

I was unable to figure out how to eliminate sufficient security parameters on my Opensearch container so that I could use the default client configuration in the unit test. The client configuration used for Opensearch is commented out.